### PR TITLE
Add GitHub action for drun integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,50 @@
+name: drun Integration Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check Docker Compose availability
+        run: docker compose version
+
+      - name: Generate Rails application
+        run: |
+          ./drun.sh rails new . --skip-bundle
+          ./drun.sh bundle install
+
+      - name: Build containers
+        run: ./drun.sh build
+
+      - name: Start services
+        run: |
+          ./drun.sh serve > serve.log 2>&1 &
+          echo $! > serve.pid
+          sleep 45
+
+      - name: Check container status
+        run: ./drun.sh ps
+
+      - name: Verify volumes
+        run: docker volume ls
+
+      - name: Run Rails about
+        run: ./drun.sh rails about
+
+      - name: Stop services
+        run: |
+          kill $(cat serve.pid)
+          ./drun.sh down
+
+      - name: Cleanup
+        run: ./drun.sh clean
+
+      - name: Display logs
+        if: always()
+        run: cat serve.log


### PR DESCRIPTION
## Summary
- set up CI workflow to test `drun.sh`
- build and run containers on PRs and pushes
- verify container status, volumes and basic Rails command

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68641184b97c8320ac7081a91522f599